### PR TITLE
Point to jekyll site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,4 @@ The [OpenEAC Alliance](https://www.openeac.org/) is a volunteer organization com
 
 For meeting updates and up-to-date communication, see our [substack](https://www.openeac.org/).
 
-## Methodologies
-
-### Published Methodologies
-
-| Category           | Methodology                                      | Author      | Approval Status | URL | Approved By |
-| ------------------ | ------------------------------------------------ | -------------- | ------------  | ------------ | ------------  |
-| Basic Decarbonization Accounting  | Decarbonization Accounting        | WattCarbon   | Pending  | [link]({{ site.baseurl }}/methodologies/basic-decarbonization-accounting/2025-02-07) | *  |
-| Whole-Building     | CALTRACK                                      | Recurve and LF Energy  | Approved  | [link]({{ site.baseurl }}/methodologies/whole-building-metered/2025-02-07) | US Department of Energy, California Public Utilities Commission | 
-| Electrification    | Quantifying energy and emissions savings for electrification using attribute based models |Elephant Energy| Pending | [link]({{ site.baseurl }}/methodologies/device-level-heating-household-electrification/2025-02-07) | *  |
-| Solar              | Self-Consumed solar PV generation                | PeerCo         | Approved | [link]({{ site.baseurl }}/methodologies/small-scale-solar-self-consumption-methodology/2025-02-07)  | Chris Segerblom, Nicholas Burgess, Sebnem Rusitschka |
-| Energy Efficiency  | Whole-building Metered Lighting                  | C3 and Redaptive | Pending  | [link]({{ site.baseurl }}/methodologies/whole-building-metered-lighting/2025-02-07)  | *  |
-
-### Submission
-Individual methodologies are added by Request. New methodologies should be in a google doc that allows for public comment. The link should then be shared with one of the OpenEAC Alliance maintainers (such as [mcgee@wattcarbon.com](mcgee@wattcarbon.com)) so that it can be added to the table above.
-
-### Approval Process
-
-The approval process proceeds in several steps:
-
-1. A Request is submitted to the OpenEAC Alliance with a new methodology.
-2. The Request is reviewed by the maintainers and added to the queue for presentation at an OpenEAC Alliance meeting.
-3. The authors present the methodology to the OpenEAC Alliance.
-4. The authors update the methodology based on feedback.
-5. Final Approval requires at least 3 reviewers must approve the methodology Request.
+For a list of our methodologies and their statuses, go to [this page](https://methods.wattcarbon.com).

--- a/index.md
+++ b/index.md
@@ -3,3 +3,28 @@ layout: home
 ---
 
 {% include_relative README.md %}
+
+## Methodologies
+
+### Published Methodologies
+
+| Category           | Methodology                                      | Author      | Approval Status | URL | Approved By |
+| ------------------ | ------------------------------------------------ | -------------- | ------------  | ------------ | ------------  |
+| Basic Decarbonization Accounting  | Decarbonization Accounting        | WattCarbon   | Pending  | [link]({{ site.baseurl }}/methodologies/basic-decarbonization-accounting/2025-02-07) | *  |
+| Whole-Building     | CALTRACK                                      | Recurve and LF Energy  | Approved  | [link]({{ site.baseurl }}/methodologies/whole-building-metered/2025-02-07) | US Department of Energy, California Public Utilities Commission |
+| Electrification    | Quantifying energy and emissions savings for electrification using attribute based models |Elephant Energy| Pending | [link]({{ site.baseurl }}/methodologies/device-level-heating-household-electrification/2025-02-07) | *  |
+| Solar              | Self-Consumed solar PV generation                | PeerCo         | Approved | [link]({{ site.baseurl }}/methodologies/small-scale-solar-self-consumption-methodology/2025-02-07)  | Chris Segerblom, Nicholas Burgess, Sebnem Rusitschka |
+| Energy Efficiency  | Whole-building Metered Lighting                  | C3 and Redaptive | Pending  | [link]({{ site.baseurl }}/methodologies/whole-building-metered-lighting/2025-02-07)  | *  |
+
+### Submission
+Individual methodologies are added by Request. New methodologies should be in a google doc that allows for public comment. The link should then be shared with one of the OpenEAC Alliance maintainers (such as [mcgee@wattcarbon.com](mcgee@wattcarbon.com)) so that it can be added to the table above.
+
+### Approval Process
+
+The approval process proceeds in several steps:
+
+1. A Request is submitted to the OpenEAC Alliance with a new methodology.
+2. The Request is reviewed by the maintainers and added to the queue for presentation at an OpenEAC Alliance meeting.
+3. The authors present the methodology to the OpenEAC Alliance.
+4. The authors update the methodology based on feedback.
+5. Final Approval requires at least 3 reviewers must approve the methodology Request.


### PR DESCRIPTION
This moves the methodology table to the jekyll site and out of the README to make it easier to render links.