### PR TITLE
Correct the lighting methodology URL, document links, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ For a link to the github page storing this work, go to [this page](https://githu
 The listed methodologies have been used for Measurement and Verification of a variety of grid interventions, such as battery storage installation, electrification, demand response, and energy efficiency projects.
 
 ### Submission
-Individual methodologies are added by Request. New methodologies are initially written in a google doc that allows for public comment. The link is then be shared with one of the OpenEAC Alliance maintainers (such as [mcgee@wattcarbon.com](mcgee@wattcarbon.com)) so that it can be added to the list of methodologies.
+Individual methodologies are added by Request. New methodologies are initially written in a google doc that allows for public comment. The link is then shared with one of the OpenEAC Alliance maintainers (such as [mcgee@wattcarbon.com](mailto:mcgee@wattcarbon.com)) so that it can be added to the list of methodologies.
 
 ### Approval Process
 
 The approval process proceeds in several steps:
 
 1. A draft methodology is published for implementation by one or more stakeholders (using google docs with public comment permission).
-2. This document is shared with the OpeneEAC Alliance maintainers to be posted onto [methods.openeac.org](https://methods.openeac.org)
+2. This document is shared with the OpenEAC Alliance maintainers to be posted onto [methods.openeac.org](https://methods.openeac.org)
 3. A minimum 30-day public comment period is opened.
 4. After the comment period is closed, the authors update the methodology based on feedback.
 5. A final version is published as a PDF copy, which is added to the `approved_documents` section of the repository along with that document's public comment history.
@@ -27,7 +27,7 @@ The approval process proceeds in several steps:
 ### Glossary
 
 - EAC (Energy Attribute Certificate): represents a unique claim to the environmental benefits of a decarbonization project. EACs are granular certificates assigned to a watt-hour of energy or a gram of CO2e that specify all attributes of the underlying energy resource, including Asset type, production time, precise location, local grid carbon emissions intensity, resource operation start date, and reporting requirements.
-- Asset: describies the energy intervention that results in EACs, such as a solar panel system, battery, demand response event, or building that underwent an energy efficiency upgrade. An Asset exists at a point of metered interconnection between a production or consumption Asset and a network of other Assets that share a common and bounded electricity grid where all imports or exports of electricity to this grid are metered.
+- Asset: describes the energy intervention that results in EACs, such as a solar panel system, battery, demand response event, or building that underwent an energy efficiency upgrade. An Asset exists at a point of metered interconnection between a production or consumption Asset and a network of other Assets that share a common and bounded electricity grid where all imports or exports of electricity to this grid are metered.
 - Meter: The source of measured data used to calculate the impact of the Asset.
 
-We also have written up a general document that includes guidelines to be applied to all methodologies and can be found [here]({{ site.baseurl }}/shared-guidelines).
+We also have written up a general document that includes guidelines to be applied to all methodologies and can be found [here](https://methods.openeac.org/shared-guidelines).

--- a/_config.yml
+++ b/_config.yml
@@ -12,12 +12,6 @@ defaults:
       path: ""
     values:
       layout: "default"
-  - scope:
-      path: "approved_documents/methodologies"
-      type: "pages"
-    values:
-      layout: redirect
-      redirect_to: "https://raw.githubusercontent.com/wattcarbon/open-eac-alliance/main/"
 plugins:
   - jekyll-redirect-from
 include: ['_pages']

--- a/_pages/DeviceLevelHeatingHouseholdElectrification.md
+++ b/_pages/DeviceLevelHeatingHouseholdElectrification.md
@@ -1,4 +1,4 @@
 ---
 permalink: /methodologies/device-level-heating-household-electrification/2025-02-07
-redirect_to: https://docs.google.com/document/d/1rQfZk2Lx5-NMdck_aFx5J_84JeMSBFNYHF9AwgIG-0k/edit?usp=sharing
+redirect_to: https://docs.google.com/document/d/1rQfZk2Lx5-NMdck_aFx5J_84JeMSBFNYHF9AwgIG-0k/view
 ---

--- a/_pages/DeviceLevelMeteredLighting.md
+++ b/_pages/DeviceLevelMeteredLighting.md
@@ -1,4 +1,9 @@
 ---
 permalink: /methodologies/device-level-metered-lighting/2025-02-07
+# The specification measures individual fixtures, so device-level is the
+# canonical URL. The whole-building URL below was published for the same PDF
+# and is kept as an alias, because a certificate may already cite it.
+redirect_from:
+  - /methodologies/whole-building-metered-lighting/2025-02-07
 redirect_to: approved_documents/methodologies/energy_efficiency/WholeBuildingMeteredLighting/2025-02-07/WholeBuildingMeteredLighting-2025-02-07.pdf
 ---

--- a/_pages/WholeBuildingMeteredDemandResponse.md
+++ b/_pages/WholeBuildingMeteredDemandResponse.md
@@ -1,4 +1,4 @@
 ---
 permalink: /methodologies/whole-building-metered-demand-response/2025-10-02
-redirect_to: https://docs.google.com/document/d/1iubiiDXDlaEd17SaZY8cbRZ7Rgt3PKWn3igQLv_kxnc/edit?usp=sharing
+redirect_to: https://docs.google.com/document/d/1iubiiDXDlaEd17SaZY8cbRZ7Rgt3PKWn3igQLv_kxnc/view
 ---

--- a/_pages/WholeBuildingMeteredLighting.md
+++ b/_pages/WholeBuildingMeteredLighting.md
@@ -1,4 +1,0 @@
----
-permalink: /methodologies/whole-building-metered-lighting/2025-02-07
-redirect_to: approved_documents/methodologies/energy_efficiency/WholeBuildingMeteredLighting/2025-02-07/WholeBuildingMeteredLighting-2025-02-07.pdf
----

--- a/_pages/WholeBuildingMeteredLoadShifting.md
+++ b/_pages/WholeBuildingMeteredLoadShifting.md
@@ -1,4 +1,4 @@
 ---
 permalink: /methodologies/whole-building-metered-load-shifting/2025-10-02
-redirect_to: https://docs.google.com/document/d/1W98gA0V1oHRCWwOA9tgJYzp1uGAT-_IKAx4r15_i9G0/edit?usp=sharing
+redirect_to: https://docs.google.com/document/d/1W98gA0V1oHRCWwOA9tgJYzp1uGAT-_IKAx4r15_i9G0/view
 ---

--- a/_pages/WholeBuildingProjectMeteredOrDeemed.md
+++ b/_pages/WholeBuildingProjectMeteredOrDeemed.md
@@ -1,4 +1,4 @@
 ---
 permalink: /methodologies/whole-building-metered-or-deemed/2025-02-07
-redirect_to: https://docs.google.com/document/d/1rQfZk2Lx5-NMdck_aFx5J_84JeMSBFNYHF9AwgIG-0k/edit?usp=sharing
+redirect_to: https://docs.google.com/document/d/1rQfZk2Lx5-NMdck_aFx5J_84JeMSBFNYHF9AwgIG-0k/view
 ---

--- a/index.md
+++ b/index.md
@@ -9,6 +9,7 @@ layout: default
 ### Standard M&V Methodologies
 
 | Methodology | External Entity | URL |
+| ------------------ | ------------------ | ------------ |
 | Whole-Building Weather Normalized Metered (OpenDSM EEMeter) | [LF Energy](https://www.lfenergy.org) | [link]({{ site.baseurl }}/methodologies/whole-building-metered/2025-02-07) |
 
 
@@ -29,7 +30,7 @@ layout: default
 ### Related Methodologies
 
 | Methodology | Published Date | URL |
-| ------------------ | ------------------------------------------------ | ------------  | ------------ |
+| ------------------ | ------------  | ------------ |
 | Decarbonization Accounting | 2025-02-07 | [link]({{ site.baseurl }}/methodologies/basic-decarbonization-accounting/2025-02-07) |
 | Demand Efficiency Calculations | 2026-02-19* | [link]({{ site.baseurl }}/methodologies/demand-efficiency-calculations/2026-02-19) |
 | Utility Bill Savings | 2026-06-23* | [link]({{ site.baseurl }}/methodologies/utility-bill-savings/2026-06-23) |


### PR DESCRIPTION
## What this changes

Three corrections to the site and the README. **No methodology document changes, and no URL is added or removed.** The set of live URLs is byte-identical before and after.

### One URL for the metered lighting methodology

The approved specification measures individual light fixtures: a line-by-line fixture audit, a pre- and post-retrofit wattage per fixture, and effective full load hours. Its methodology section says the method "can be used for an individual light fixture or set of light fixtures". No step reads a whole-building meter. The index is correct to list it as Device granularity.

A second page published the same PDF at `/methodologies/whole-building-metered-lighting/2025-02-07`, under a granularity the document does not have. The two pages are collapsed into the device-level page, and the whole-building URL is kept as a `redirect_from` alias so a certificate that cites it still resolves.

The PDF keeps its current path. The directory and filename also read whole-building, but that path may be linked from outside this repository. Renaming it needs a decision about how to preserve the old URL, so it is left alone here.

### Read-only document links

Four pages sent readers to a Google Doc `/edit` URL, while the other seven used `/view`. A published methodology is a document of record, and a certificate cites it. An edit link invites a reader to change text that a claim already depends on.

### README, index tables, and an inert default

The maintainer address had no `mailto:` scheme, so the site rendered a relative link that returns 404. The Shared Guidelines link used `site.baseurl`, which resolves on the site but prints literally on github.com, where the README is the landing page. Three spelling and grammar corrections in the same file.

Two index tables had a missing delimiter row and a four-cell delimiter over three columns. Kramdown tolerated both, so the rendered output does not change.

The default that gave every page under `approved_documents/methodologies` a redirect to the raw GitHub root matched nothing, because the PDFs there are static files and not pages. It would have taken effect the moment somebody added front matter to the solar comment history.

## Checks

- All 14 permalinks and all three PDFs return HTTP 200 on the live site before the change.
- Front matter parses for all 13 pages. No permalink collision. Every `approved_documents` redirect target exists on disk.
- The URL set, including the new alias, is identical to `main`.
- `approved_documents/` is untouched.

## Not in this pull request

Found while reading the methodologies, and needing a decision rather than a patch:

- Nine of eleven methodologies redirect to Google Docs, which have no version in the URL. Shared Guidelines §3.1.6.3 requires a certificate to cite a URL that "points to the specific version used to generate the certificate".
- The approved `CommonDecarbonization` PDF is unreachable from the site, and has diverged from the live document in both directions.
- Five methodologies are still marked in the comment period, two of them for over 300 days.
- Concrete errors inside individual methodologies, including an electric water heater table that duplicates the gas table, a covariance matrix that does not derive from its own example data, and a ResStock column listed twice in a sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
