### PR TITLE
Serve this site per branch on a development box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Jekyll build output. The preview container writes these to /tmp, but a build
+# run outside it lands here.
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Working on this repository
+
+This repository publishes the OpenEAC Alliance methodologies as a Jekyll site at
+[methods.openeac.org](https://methods.openeac.org). GitHub Pages builds it from
+`main`, using its legacy pipeline: the `github-pages` gem, which pins Jekyll 3
+and a fixed plugin list.
+
+## What the files are
+
+- `index.md` lists every methodology. It is the only place a methodology is
+  advertised, so a new one is not published until it appears here.
+- `_pages/*.md` are redirect stubs, one per methodology. Each carries a dated
+  `permalink` and a `redirect_to`. There is no prose in them.
+- `approved_documents/` holds the frozen PDF of each approved methodology, with
+  its public comment history beside it.
+- `_config.yml`, `Dockerfile` and `compose.yml` are site and preview plumbing.
+
+## A permalink is a citation
+
+Every certificate records the URL of the methodology that produced it. A
+permalink is therefore a published identifier, not a routing detail:
+
+- **Never change or delete a `permalink`.** To rename one, add the old value to
+  the new page's `redirect_from` list, so the old URL still resolves.
+- **Never move a file under `approved_documents/`.** Those paths are reachable
+  from outside this repository.
+- Link a Google Doc with `/view`, never `/edit`. A reader must not be able to
+  change a document that a published claim already depends on.
+
+## Preview a change
+
+```sh
+docker compose up          # then open http://localhost:4000
+```
+
+The site rebuilds when you edit a file, so a reload shows the change.
+
+To check a change without reading it, build it:
+
+```sh
+docker compose run --rm site jekyll build --destination /tmp/_site
+```
+
+That fails on a broken permalink, a duplicate one, or unparseable front matter,
+which is most of what can go wrong here.
+
+## Preview through the server, not the built output
+
+Do not point a static file server at a built `_site`. It produces a convincing
+false alarm.
+
+GitHub Pages resolves an extensionless request such as
+`/methodologies/whole-building-metered/2025-02-07` to the `2025-02-07.html` file
+it generated, and every link on this site is extensionless. A plain file server
+returns 404 for all of them, which reads as a site full of broken links when
+nothing is broken. `jekyll serve`, which `docker compose up` runs, resolves them
+the way Pages does.
+
+`jekyll-redirect-from` also writes **absolute** URLs, built from `site.url`. The
+preview sets that to wherever you are serving it, so redirects point at the host
+you are reading. Set `SITE_URL` to override it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Image for building and previewing this site locally.
+#
+# GitHub Pages builds this repository with its legacy pipeline, which pins the
+# `github-pages` gem: Jekyll 3 plus a fixed plugin list. Installing that same
+# gem here keeps a local preview faithful to the published site. Plain
+# `gem install jekyll` pulls Jekyll 4, which renders this site differently
+# enough to hide a routing mistake until it is published.
+#
+# git must be installed even though it need not resolve the checkout. The
+# jekyll-theme-primer layout reads site.github, which shells out to
+# `git rev-parse HEAD`. A git that exits non-zero costs one warning; a missing
+# git binary raises ENOENT and fails the build. curl is for the healthcheck.
+FROM ruby:3.3-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential git curl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN gem install --no-document github-pages
+
+WORKDIR /site

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,10 @@ title: OpenEAC Alliance
 description: "Repository for M&V methodology for EACs in WEATS"
 theme: jekyll-theme-primer
 markdown: kramdown
+# Keep the Sass compiler's cache out of the checkout, so building the site
+# locally leaves no untracked directory behind. Does not affect the output.
+sass:
+  cache_location: /tmp/.sass-cache
 defaults:
   -
     scope:

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,52 @@
+# Preview this site as it will be served:
+#
+#   docker compose up          then open http://localhost:4000
+#   docker compose run --rm site jekyll build --destination /tmp/_site
+#
+# Serve it through `jekyll serve` rather than pointing a file server at a built
+# _site. GitHub Pages resolves an extensionless request such as
+# /methodologies/whole-building-metered/2025-02-07 to the .html file it
+# generated, and every link on this site is extensionless. A plain file server
+# returns 404 for all of them, which reads as a site full of broken links when
+# nothing is broken. `jekyll serve` resolves them the way Pages does.
+
+services:
+  site:
+    build: .
+    ports:
+      - "${SITE_PORT:-4000}:4000"
+    volumes:
+      - .:/site
+    environment:
+      # Stops jekyll-github-metadata probing the GitHub API to work out which
+      # repository this is. The theme reads site.github, so without this every
+      # build waits on an unauthenticated API call.
+      PAGES_REPO_NWO: wattcarbon/open-eac-alliance
+      # In its development environment `jekyll serve` overwrites site.url with
+      # its own listening address. jekyll-redirect-from writes absolute URLs
+      # into every methodology page, so without production every redirect would
+      # point at http://0.0.0.0:4000 whatever SITE_URL says. Pages also builds
+      # with production.
+      JEKYLL_ENV: production
+      SITE_URL: ${SITE_URL:-http://localhost:4000}
+    # The generated site goes to /tmp, and _config.yml puts the Sass cache
+    # there too, so previewing never writes into the checkout.
+    #
+    # force_polling: the checkout arrives over a bind mount, where inotify is
+    # not dependable, so without it an edit does not rebuild.
+    command:
+      - sh
+      - -euc
+      - |
+        printf 'url: "%s"\nbaseurl: ""\n' "$${SITE_URL}" > /tmp/preview.yml
+        exec jekyll serve \
+          --host 0.0.0.0 --port 4000 \
+          --config _config.yml,/tmp/preview.yml \
+          --destination /tmp/_site \
+          --force_polling
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:4000/"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 30s


### PR DESCRIPTION
Closed in favour of #23, which added the container preview on its own. This description is kept accurate for anyone reading back through it.

## What this adds

A containerised preview of this site, so a change can be read as it will be served, before it is merged. It runs anywhere docker does: a laptop, or a development box that serves each branch at its own address.

Until now, reviewing a change here meant merging it and watching the published site, or building the site by hand. Both hide the two ways this repo actually breaks: a permalink that no longer resolves, and a redirect that points at the wrong host.

| File | Purpose |
| --- | --- |
| `Dockerfile` | Ruby, plus the same gem set GitHub Pages builds with |
| `compose.yml` | runs `jekyll serve` on port 4000, with a healthcheck |
| `_config.yml` | sends the Sass cache to `/tmp`, so a local build leaves the checkout clean |
| `.gitignore` | the build output and caches that a build outside the container leaves behind |
| `AGENTS.md` | how to verify a change, and why a permalink is a citation |

`AGENTS.md` also records the rule that matters most in this repo: a permalink is a published identifier, because every certificate records the URL of the methodology that produced it. Renaming one means adding the old value to `redirect_from`, and a file under `approved_documents/` must not move at all.

## Three findings worth knowing

Each of these hides a broken site rather than announcing itself.

**The image installs the `github-pages` gem, not plain Jekyll.** GitHub Pages builds this site with its legacy pipeline, which pins Jekyll 3 and a fixed plugin list. Jekyll 4 renders this site differently enough to hide a routing mistake until it reaches the published site.

**Jekyll runs with `JEKYLL_ENV=production`.** In its development environment `jekyll serve` overwrites `site.url` with its own listening address. `jekyll-redirect-from` writes absolute URLs into every methodology page, so without this each one sent the reader to `http://0.0.0.0:4000`. This was observed while testing, not anticipated.

**The image installs git although git cannot resolve the checkout inside the container.** The `jekyll-theme-primer` layout reads `site.github`, which shells out to `git rev-parse HEAD`. A git that exits non-zero costs one warning. A missing git binary raises `ENOENT` and fails the whole build.

## A note on serving the built output directly

A rendered `_site` served by an ordinary static file server is not a faithful test, and this is worth stating because it produces a convincing false alarm.

GitHub Pages resolves an extensionless request such as `/methodologies/whole-building-metered/2025-02-07` to the `2025-02-07.html` file it generated. Every link on the site is extensionless. A plain file server returns 404 for all of them, which reads as a site full of broken links when nothing is broken. `jekyll serve` resolves them the way Pages does, so previewing through it avoids the trap entirely.

## Checks

Run against the container, then torn down:

- The service comes up healthy and answers on port 4000.
- All 14 permalinks return 200, requested extensionless, exactly as the pages link them.
- Redirect pages carry the URL of the host the preview is served on, rather than a hardcoded one.
- An edit to `index.md` appears in the served site within six seconds.
- `jekyll build` exits 0 inside the container.
- The checkout stays clean while the container runs: the generated site, the Jekyll cache and the Sass cache are all written outside it, so `git status` is unaffected and nothing is left behind.
- `docker compose config` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
